### PR TITLE
Boolean kernels now use check_X_T

### DIFF
--- a/MKLpy/metrics/pairwise.py
+++ b/MKLpy/metrics/pairwise.py
@@ -72,12 +72,12 @@ def SSK_kernel(X, T=None, k=2):
 #----------BOOLEAN KERNELS----------
 
 def monotone_conjunctive_kernel(X,T=None,c=2):
-    T = X if type(T) == types.NoneType else T
+    X, T = check_X_T(X, T)
     L = np.dot(X,T.T)
     return binom(L,c)
 
 def monotone_disjunctive_kernel(X,T=None,d=2):
-    T = X if type(T) == types.NoneType else T
+    X, T = check_X_T(X, T)
     L = np.dot(X,T.T)
     n = X.shape[1]
 
@@ -95,7 +95,7 @@ def monotone_disjunctive_kernel(X,T=None,d=2):
 
 
 def monotone_dnf_kernel(X,T=None,d=2,c=2):
-    T = X if type(T) == types.NoneType else T
+    X, T = check_X_T(X, T)
     n = X.shape[1]
     n_c = binom(n,c)
     XX = np.dot(X.sum(axis=1).reshape(X.shape[0],1), np.ones((1,T.shape[0])))


### PR DESCRIPTION
Hi Ivano,
The boolean kernels to check if the parameter T is None use the module types that is not imported. I replaced the check with the function check_X_T.